### PR TITLE
Utilize SiraUtil More

### DIFF
--- a/UITweaks/Plugin.cs
+++ b/UITweaks/Plugin.cs
@@ -18,7 +18,7 @@ namespace UITweaks
 
             zen.OnApp<UIAppInstaller>().WithParameters(pConf);
             zen.OnMenu<UIMenuInstaller>();
-            zen.OnGame<UIGameInstaller>().Expose<ScoreMultiplierUIController>().Expose<ComboUIController>().Expose<GameEnergyUIPanel>().OnlyForStandard();
+            zen.OnGame<UIGameInstaller>().Expose<ComboUIController>().Expose<GameEnergyUIPanel>().ShortCircuitForTutorial().ShortCircuitForMultiplayer();
         }
 
         [OnEnable]

--- a/UITweaks/Plugin.cs
+++ b/UITweaks/Plugin.cs
@@ -18,7 +18,7 @@ namespace UITweaks
 
             zen.OnApp<UIAppInstaller>().WithParameters(pConf);
             zen.OnMenu<UIMenuInstaller>();
-            zen.OnGame<UIGameInstaller>().OnlyForStandard();
+            zen.OnGame<UIGameInstaller>().Expose<ScoreMultiplierUIController>().Expose<ComboUIController>().Expose<GameEnergyUIPanel>().OnlyForStandard();
         }
 
         [OnEnable]

--- a/UITweaks/Services/ComboColorer.cs
+++ b/UITweaks/Services/ComboColorer.cs
@@ -1,5 +1,5 @@
-﻿using BS_Utils.Utilities;
-using HMUI;
+﻿using HMUI;
+using IPA.Utilities;
 using UnityEngine;
 using Zenject;
 
@@ -18,11 +18,11 @@ namespace UITweaks.Services
             var comboFCLines = GameObject.Find("ComboPanel").GetComponentsInChildren<ImageView>();
             _fcLines = comboFCLines;
 
-            ReflectionUtil.SetPrivateField(_fcLines[0], "_gradient", true);
+            ReflectionUtil.SetField(_fcLines[0], "_gradient", true);
             _fcLines[0].color0 = new Color(1f, 1f, 0.75f);
             _fcLines[0].color1 = Color.yellow;
 
-            ReflectionUtil.SetPrivateField(_fcLines[1], "_gradient", true);
+            ReflectionUtil.SetField(_fcLines[1], "_gradient", true);
             _fcLines[1].color0 = Color.yellow;
             _fcLines[1].color1 = new Color(1f, 1f, 0.75f);
         }

--- a/UITweaks/Services/ComboColorer.cs
+++ b/UITweaks/Services/ComboColorer.cs
@@ -7,15 +7,19 @@ namespace UITweaks.Services
 {
     public class ComboColorer : IInitializable
     {
+        ComboUIController _comboUIController;
         PluginConfig.ComboConfig _config;
         ImageView[] _fcLines;
 
-        public ComboColorer(PluginConfig.ComboConfig config) =>
+        public ComboColorer(PluginConfig.ComboConfig config, ComboUIController comboUIController)
+        {
+            _comboUIController = comboUIController;
             _config = config;
+        }
 
         public void Initialize()
         { 
-            var comboFCLines = GameObject.Find("ComboPanel").GetComponentsInChildren<ImageView>();
+            var comboFCLines = _comboUIController.GetComponentsInChildren<ImageView>();
             _fcLines = comboFCLines;
 
             ReflectionUtil.SetField(_fcLines[0], "_gradient", true);

--- a/UITweaks/Services/EnergyBarColorer.cs
+++ b/UITweaks/Services/EnergyBarColorer.cs
@@ -1,5 +1,7 @@
 ﻿using HMUI;
+using IPA.Utilities;
 using UnityEngine;
+using UnityEngine.UI;
 using Zenject;
 
 namespace UITweaks.Services
@@ -9,7 +11,7 @@ namespace UITweaks.Services
         PluginConfig.EnergyBarConfig _config;
         IGameEnergyCounter _energy;
         GameEnergyUIPanel _panel;
-        ImageView _bar;
+        Image _bar;
 
         public EnergyBarColorer(PluginConfig.EnergyBarConfig config, IGameEnergyCounter gameEnergyCounter, GameEnergyUIPanel gameEnergyUIPanel)
         {
@@ -20,7 +22,7 @@ namespace UITweaks.Services
 
         public void Initialize()
         {
-            var bar = _panel.transform.Find("EnergyBar").GetComponent<ImageView>();
+            var bar = _panel.GetField<Image, GameEnergyUIPanel>("_energyBar");
             _bar = bar;
         }
 

--- a/UITweaks/Services/EnergyBarColorer.cs
+++ b/UITweaks/Services/EnergyBarColorer.cs
@@ -7,19 +7,21 @@ namespace UITweaks.Services
     public class EnergyBarColorer : IInitializable, ITickable
     {
         PluginConfig.EnergyBarConfig _config;
-        GameEnergyCounter _energy;
+        IGameEnergyCounter _energy;
+        GameEnergyUIPanel _panel;
         ImageView _bar;
 
-        public EnergyBarColorer(PluginConfig.EnergyBarConfig config) =>
+        public EnergyBarColorer(PluginConfig.EnergyBarConfig config, IGameEnergyCounter gameEnergyCounter, GameEnergyUIPanel gameEnergyUIPanel)
+        {
+            _energy = gameEnergyCounter;
+            _panel = gameEnergyUIPanel;
             _config = config;
+        }
 
         public void Initialize()
         {
-            var bar = GameObject.Find("EnergyBar").GetComponent<ImageView>();
+            var bar = _panel.transform.Find("EnergyBar").GetComponent<ImageView>();
             _bar = bar;
-
-            var energy = GameObject.Find("GameplayData").GetComponent<GameEnergyCounter>();
-            _energy = energy;
         }
 
         public void Tick()

--- a/UITweaks/Services/MultiplierColorer.cs
+++ b/UITweaks/Services/MultiplierColorer.cs
@@ -7,22 +7,20 @@ namespace UITweaks.Services
     public class MultiplierColorer : IInitializable, ITickable
     {
         PluginConfig.MultiplierConfig _config;
-        ScoreMultiplierUIController _ui;
         CurvedTextMeshPro[] _mainTextGO;
         ImageView _bg;
         ImageView _fg;
 
-        public MultiplierColorer(PluginConfig.MultiplierConfig config, ScoreMultiplierUIController scoreMultiplierUIController)
+        public MultiplierColorer(PluginConfig.MultiplierConfig config)
         {
-            _ui = scoreMultiplierUIController;
             _config = config;
         }
 
         public void Initialize()
         {
-            var text = _ui.transform.Find("TextPanel").GetComponentsInChildren<CurvedTextMeshPro>();
-            var bg = _ui.transform.Find("BGCircle").GetComponent<ImageView>();
-            var fg = _ui.transform.Find("FGCircle").GetComponent<ImageView>();
+            var text = GameObject.Find("TextPanel").GetComponentsInChildren<CurvedTextMeshPro>();
+            var bg = GameObject.Find("BGCircle").GetComponent<ImageView>();
+            var fg = GameObject.Find("FGCircle").GetComponent<ImageView>();
 
             _mainTextGO = text;
             _bg = bg;

--- a/UITweaks/Services/MultiplierColorer.cs
+++ b/UITweaks/Services/MultiplierColorer.cs
@@ -7,17 +7,22 @@ namespace UITweaks.Services
     public class MultiplierColorer : IInitializable, ITickable
     {
         PluginConfig.MultiplierConfig _config;
+        ScoreMultiplierUIController _ui;
         CurvedTextMeshPro[] _mainTextGO;
         ImageView _bg;
         ImageView _fg;
 
-        public MultiplierColorer(PluginConfig.MultiplierConfig config) => _config = config;
+        public MultiplierColorer(PluginConfig.MultiplierConfig config, ScoreMultiplierUIController scoreMultiplierUIController)
+        {
+            _ui = scoreMultiplierUIController;
+            _config = config;
+        }
 
         public void Initialize()
         {
-            var text = GameObject.Find("TextPanel").GetComponentsInChildren<CurvedTextMeshPro>();
-            var bg = GameObject.Find("BGCircle").GetComponent<ImageView>();
-            var fg = GameObject.Find("FGCircle").GetComponent<ImageView>();
+            var text = _ui.transform.Find("TextPanel").GetComponentsInChildren<CurvedTextMeshPro>();
+            var bg = _ui.transform.Find("BGCircle").GetComponent<ImageView>();
+            var fg = _ui.transform.Find("FGCircle").GetComponent<ImageView>();
 
             _mainTextGO = text;
             _bg = bg;

--- a/UITweaks/UITweaks.csproj
+++ b/UITweaks/UITweaks.csproj
@@ -46,11 +46,6 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="BS_Utils">
-      <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="GameplayCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
       <Private>False</Private>

--- a/UITweaks/manifest.json
+++ b/UITweaks/manifest.json
@@ -9,8 +9,7 @@
   "dependsOn": {
     "BSIPA": "^4.1.6",
     "SiraUtil": "^2.5.2",
-    "BeatSaberMarkupLanguage": "^1.5.1",
-    "BS Utils": "^1.8.0"
+    "BeatSaberMarkupLanguage": "^1.5.1"
   },
   "features": []
 }

--- a/UITweaks/manifest.json
+++ b/UITweaks/manifest.json
@@ -10,6 +10,5 @@
     "BSIPA": "^4.1.6",
     "SiraUtil": "^2.5.2",
     "BeatSaberMarkupLanguage": "^1.5.1"
-  },
-  "features": []
+  }
 }


### PR DESCRIPTION
What this PR does:
- Removes BS Utils as a dependency (it was unnecessary and technically less efficient)
- Cleaned up the manifest
- Replaces all avoidable calls to GameObject.Find with Zenject injections
- Gives support for campaign levels

Suggestion: Don't leave out your gitignore or build props / build target files! They just make it harder for people who want to contribute to setup and can accidentally slip in extra files that you wouldn't want in the commit history/repo.